### PR TITLE
JNG-4864 Remove cast before time component extraction in hsqldb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <judo-sdk-common-version>1.0.4.20230330_222100_3c176073_develop</judo-sdk-common-version>
         <judo-dispatcher-api-version>1.0.2</judo-dispatcher-api-version>
         <judo-operation-utils-version>1.1.3.20230324_114642_660d83a9_develop</judo-operation-utils-version>
-        <judo-runtime-core-version>1.0.6.20230524_134847_bef03d7a_develop</judo-runtime-core-version>
+        <judo-runtime-core-version>1.0.6.20230531_122635_76067dd8_bugfix_JNG_4864_Remove_cast_before_time_component_extraction_in_hsqldb</judo-runtime-core-version>
         <structured-map-proxy-version>2.0.0.20230330_221859_8a965acd_develop</structured-map-proxy-version>
 
         <judo-tatami-base-version>1.1.6.20230522_110523_e0b1a4a7_develop</judo-tatami-base-version>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4864" title="JNG-4864" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4864</a>  Error when executing query dao with timestamp return type
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
JNG-4864 Remove cast before time component extraction in hsqldb