### PR TITLE
JNG-5075 fix transfers default attribute name in transformation

### DIFF
--- a/judo-tatami-jsl-jsl2psm/src/main/epsilon/transformations/psm/modules/structure/transferDeclarationTransferAttribute.etl
+++ b/judo-tatami-jsl-jsl2psm/src/main/epsilon/transformations/psm/modules/structure/transferDeclarationTransferAttribute.etl
@@ -85,7 +85,7 @@ rule CreateMappedTransferAttributeEntityDefault
     transform s : JSL!TransferFieldDeclaration
     to t : JUDOPSM!TransferAttribute {
       guard: s.maps() and s.getterExpr.features.first.member.getDefault().isDefined() and s.getDefault().isUndefined()
-      t.name = defaultDefaultNamePrefix + s.getterExpr.features.first.member.name + defaultDefaultNameMidfix + s.getterExpr.features.first.member.eContainer.name + defaultDefaultNamePostfix;
+      t.name = defaultDefaultNamePrefix + s.name + defaultDefaultNameMidfix + s.eContainer.eContainer.name + defaultDefaultNamePostfix;
       t.setId("(jsl/" + s.getId() + ")/CreateMappedTransferAttributeEntityDefault");      
       t.binding = s.getterExpr.features.first.member.getDefault().equivalent("CreateDefaultValueForPrimitiveEntityMember");
       t.dataType = s.referenceType.getPSMEquivalent();

--- a/judo-tatami-jsl-jsl2psm/src/main/epsilon/transformations/psm/modules/structure/transferDeclarationTransferAttribute.etl
+++ b/judo-tatami-jsl-jsl2psm/src/main/epsilon/transformations/psm/modules/structure/transferDeclarationTransferAttribute.etl
@@ -85,7 +85,7 @@ rule CreateMappedTransferAttributeEntityDefault
     transform s : JSL!TransferFieldDeclaration
     to t : JUDOPSM!TransferAttribute {
       guard: s.maps() and s.getterExpr.features.first.member.getDefault().isDefined() and s.getDefault().isUndefined()
-      t.name = defaultDefaultNamePrefix + s.name + defaultDefaultNameMidfix + s.getterExpr.features.first.member.eContainer.name + defaultDefaultNamePostfix;
+      t.name = defaultDefaultNamePrefix + s.getterExpr.features.first.member.name + defaultDefaultNameMidfix + s.getterExpr.features.first.member.eContainer.name + defaultDefaultNamePostfix;
       t.setId("(jsl/" + s.getId() + ")/CreateMappedTransferAttributeEntityDefault");      
       t.binding = s.getterExpr.features.first.member.getDefault().equivalent("CreateDefaultValueForPrimitiveEntityMember");
       t.dataType = s.referenceType.getPSMEquivalent();

--- a/judo-tatami-jsl-jsl2psm/src/test/java/hu/blackbelt/judo/tatami/jsl/jsl2psm/AbstractTest.java
+++ b/judo-tatami-jsl-jsl2psm/src/test/java/hu/blackbelt/judo/tatami/jsl/jsl2psm/AbstractTest.java
@@ -20,7 +20,6 @@ package hu.blackbelt.judo.tatami.jsl.jsl2psm;
  * #L%
  */
 
-import org.eclipse.emf.common.util.EList;
 import org.slf4j.Logger;
 import hu.blackbelt.judo.meta.jsl.jsldsl.runtime.JslDslModel;
 import hu.blackbelt.judo.meta.jsl.jsldsl.support.JslDslModelResourceSupport;

--- a/judo-tatami-jsl-jsl2psm/src/test/java/hu/blackbelt/judo/tatami/jsl/jsl2psm/AbstractTest.java
+++ b/judo-tatami-jsl-jsl2psm/src/test/java/hu/blackbelt/judo/tatami/jsl/jsl2psm/AbstractTest.java
@@ -20,6 +20,7 @@ package hu.blackbelt.judo.tatami.jsl.jsl2psm;
  * #L%
  */
 
+import org.eclipse.emf.common.util.EList;
 import org.slf4j.Logger;
 import hu.blackbelt.judo.meta.jsl.jsldsl.runtime.JslDslModel;
 import hu.blackbelt.judo.meta.jsl.jsldsl.support.JslDslModelResourceSupport;
@@ -192,6 +193,7 @@ abstract public class AbstractTest {
     }
 
     public TransferAttribute assertMappedTransferObjectAttribute(String toName, String attrName) {
+        final EList<TransferAttribute> attr2 = assertMappedTransferObject(toName).getAttributes();
         final Optional<TransferAttribute> attr = assertMappedTransferObject(toName).getAttributes().stream().filter(e -> e.getName().equals(attrName)).findAny();
         assertTrue(attr.isPresent());
         return attr.get();

--- a/judo-tatami-jsl-jsl2psm/src/test/java/hu/blackbelt/judo/tatami/jsl/jsl2psm/AbstractTest.java
+++ b/judo-tatami-jsl-jsl2psm/src/test/java/hu/blackbelt/judo/tatami/jsl/jsl2psm/AbstractTest.java
@@ -193,7 +193,6 @@ abstract public class AbstractTest {
     }
 
     public TransferAttribute assertMappedTransferObjectAttribute(String toName, String attrName) {
-        final EList<TransferAttribute> attr2 = assertMappedTransferObject(toName).getAttributes();
         final Optional<TransferAttribute> attr = assertMappedTransferObject(toName).getAttributes().stream().filter(e -> e.getName().equals(attrName)).findAny();
         assertTrue(attr.isPresent());
         return attr.get();

--- a/judo-tatami-jsl-jsl2psm/src/test/java/hu/blackbelt/judo/tatami/jsl/jsl2psm/transferobject/JslTransferObjectConstructor2PsmTransferObjectTypeTest.java
+++ b/judo-tatami-jsl-jsl2psm/src/test/java/hu/blackbelt/judo/tatami/jsl/jsl2psm/transferobject/JslTransferObjectConstructor2PsmTransferObjectTypeTest.java
@@ -157,7 +157,7 @@ public class JslTransferObjectConstructor2PsmTransferObjectTypeTest extends Abst
         DataProperty mappedAttributeEntityDefaultDefault = assertDataProperty("_Entity", "_attribute_Default_Entity");
         assertEquals("1", mappedAttributeEntityDefaultDefault.getGetterExpression().getExpression());
         assertEquals(mappedAttributeEntityDefaultDefault, mappedAttributeEntityDefault.getDefaultValue());
-        TransferAttribute mappedAttributeEntityDefaultDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_attribute_Default_Entity");
+        TransferAttribute mappedAttributeEntityDefaultDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_mappedAttributeEntityDefault_Default_TransferObjectConstructorModel");
         assertEquals(mappedAttributeEntityDefaultDefaultAttribute.getBinding(), mappedAttributeEntityDefaultDefault);
 
         TransferAttribute mappedIdentifierEntityDefault = assertMappedTransferObjectAttribute("Mapped", "mappedIdentifierEntityDefault");
@@ -167,7 +167,7 @@ public class JslTransferObjectConstructor2PsmTransferObjectTypeTest extends Abst
         DataProperty mappedIdentifierEntityDefaultDefault = assertDataProperty("_Entity", "_id_Default_Entity");
         assertEquals("1", mappedIdentifierEntityDefaultDefault.getGetterExpression().getExpression());
         assertEquals(mappedIdentifierEntityDefaultDefault, mappedIdentifierEntityDefault.getDefaultValue());
-        TransferAttribute mappedIdentifierEntityDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_id_Default_Entity");
+        TransferAttribute mappedIdentifierEntityDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_mappedIdentifierEntityDefault_Default_TransferObjectConstructorModel");
         assertEquals(mappedIdentifierEntityDefaultAttribute.getBinding(), mappedIdentifierEntityDefaultDefault);
 
         TransferAttribute mappedEnumEntityDefault = assertMappedTransferObjectAttribute("Mapped", "mappedEnumEntityDefault");
@@ -177,7 +177,7 @@ public class JslTransferObjectConstructor2PsmTransferObjectTypeTest extends Abst
         DataProperty mappedEnumEntityDefaultDefault = assertDataProperty("_Entity", "_enum_Default_Entity");
         assertEquals("TransferObjectConstructorModel::TransferObjectConstructorModel::MyEnum#Bombastic", mappedEnumEntityDefaultDefault.getGetterExpression().getExpression());
         assertEquals(mappedEnumEntityDefaultDefault, mappedEnumEntityDefault.getDefaultValue());
-        TransferAttribute mappedEnumEntityDefaultDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_enum_Default_Entity");
+        TransferAttribute mappedEnumEntityDefaultDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_mappedEnumEntityDefault_Default_TransferObjectConstructorModel");
         assertEquals(mappedEnumEntityDefaultDefaultAttribute.getBinding(), mappedEnumEntityDefaultDefault);        
 
         TransferAttribute mappedEnumAncestorEntityDefault = assertMappedTransferObjectAttribute("Mapped", "mappedEnumAncestorEntityDefault");
@@ -187,7 +187,7 @@ public class JslTransferObjectConstructor2PsmTransferObjectTypeTest extends Abst
         DataProperty mappedEnumAncestorEntityDefaultDefault = assertDataProperty("_EntityAncestor", "_enumAncestor_Default_EntityAncestor");
         assertEquals("TransferObjectConstructorModel::TransferObjectConstructorModel::MyEnum#Atomic", mappedEnumAncestorEntityDefaultDefault.getGetterExpression().getExpression());
         assertEquals(mappedEnumAncestorEntityDefaultDefault, mappedEnumAncestorEntityDefault.getDefaultValue());
-        TransferAttribute mappedEnumAncestorEntityDefaultDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_enumAncestor_Default_EntityAncestor");
+        TransferAttribute mappedEnumAncestorEntityDefaultDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_mappedEnumAncestorEntityDefault_Default_TransferObjectConstructorModel");
         assertEquals(mappedEnumAncestorEntityDefaultDefaultAttribute.getBinding(), mappedEnumAncestorEntityDefaultDefault);        
 
         TransferAttribute mappedAttributeAncestorEntityDefault = assertMappedTransferObjectAttribute("Mapped", "mappedAttributeAncestorEntityDefault");
@@ -197,7 +197,7 @@ public class JslTransferObjectConstructor2PsmTransferObjectTypeTest extends Abst
         DataProperty mappedAttributeAncestorEntityDefaultDefault = assertDataProperty("_EntityAncestor", "_attributeAncestor_Default_EntityAncestor");
         assertEquals("(-1)", mappedAttributeAncestorEntityDefaultDefault.getGetterExpression().getExpression());
         assertEquals(mappedAttributeAncestorEntityDefaultDefault, mappedAttributeAncestorEntityDefault.getDefaultValue());
-        TransferAttribute mappedAttributeAncestorEntityDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_attributeAncestor_Default_EntityAncestor");
+        TransferAttribute mappedAttributeAncestorEntityDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_mappedAttributeAncestorEntityDefault_Default_TransferObjectConstructorModel");
         assertEquals(mappedAttributeAncestorEntityDefaultAttribute.getBinding(), mappedAttributeAncestorEntityDefaultDefault);
 
         TransferAttribute mappedIdentifierAncestorEntityDefault = assertMappedTransferObjectAttribute("Mapped", "mappedIdentifierAncestorEntityDefault");
@@ -207,7 +207,7 @@ public class JslTransferObjectConstructor2PsmTransferObjectTypeTest extends Abst
         DataProperty mappedIdentifierAncestorEntityDefaultDefault = assertDataProperty("_EntityAncestor", "_identifierAncestor_Default_EntityAncestor");
         assertEquals("(-1)", mappedIdentifierAncestorEntityDefaultDefault.getGetterExpression().getExpression());
         assertEquals(mappedIdentifierAncestorEntityDefaultDefault, mappedIdentifierAncestorEntityDefault.getDefaultValue());
-        TransferAttribute mappedIdentifierAncestorEntityDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_identifierAncestor_Default_EntityAncestor");
+        TransferAttribute mappedIdentifierAncestorEntityDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_mappedIdentifierAncestorEntityDefault_Default_TransferObjectConstructorModel");
         assertEquals(mappedIdentifierAncestorEntityDefaultAttribute.getBinding(), mappedIdentifierAncestorEntityDefaultDefault);
 
         

--- a/judo-tatami-jsl-jsl2psm/src/test/java/hu/blackbelt/judo/tatami/jsl/jsl2psm/transferobject/JslTransferObjectConstructor2PsmTransferObjectTypeTest.java
+++ b/judo-tatami-jsl-jsl2psm/src/test/java/hu/blackbelt/judo/tatami/jsl/jsl2psm/transferobject/JslTransferObjectConstructor2PsmTransferObjectTypeTest.java
@@ -157,7 +157,7 @@ public class JslTransferObjectConstructor2PsmTransferObjectTypeTest extends Abst
         DataProperty mappedAttributeEntityDefaultDefault = assertDataProperty("_Entity", "_attribute_Default_Entity");
         assertEquals("1", mappedAttributeEntityDefaultDefault.getGetterExpression().getExpression());
         assertEquals(mappedAttributeEntityDefaultDefault, mappedAttributeEntityDefault.getDefaultValue());
-        TransferAttribute mappedAttributeEntityDefaultDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_mappedAttributeEntityDefault_Default_Entity");
+        TransferAttribute mappedAttributeEntityDefaultDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_attribute_Default_Entity");
         assertEquals(mappedAttributeEntityDefaultDefaultAttribute.getBinding(), mappedAttributeEntityDefaultDefault);
 
         TransferAttribute mappedIdentifierEntityDefault = assertMappedTransferObjectAttribute("Mapped", "mappedIdentifierEntityDefault");
@@ -167,7 +167,7 @@ public class JslTransferObjectConstructor2PsmTransferObjectTypeTest extends Abst
         DataProperty mappedIdentifierEntityDefaultDefault = assertDataProperty("_Entity", "_id_Default_Entity");
         assertEquals("1", mappedIdentifierEntityDefaultDefault.getGetterExpression().getExpression());
         assertEquals(mappedIdentifierEntityDefaultDefault, mappedIdentifierEntityDefault.getDefaultValue());
-        TransferAttribute mappedIdentifierEntityDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_mappedIdentifierEntityDefault_Default_Entity");
+        TransferAttribute mappedIdentifierEntityDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_id_Default_Entity");
         assertEquals(mappedIdentifierEntityDefaultAttribute.getBinding(), mappedIdentifierEntityDefaultDefault);
 
         TransferAttribute mappedEnumEntityDefault = assertMappedTransferObjectAttribute("Mapped", "mappedEnumEntityDefault");
@@ -177,7 +177,7 @@ public class JslTransferObjectConstructor2PsmTransferObjectTypeTest extends Abst
         DataProperty mappedEnumEntityDefaultDefault = assertDataProperty("_Entity", "_enum_Default_Entity");
         assertEquals("TransferObjectConstructorModel::TransferObjectConstructorModel::MyEnum#Bombastic", mappedEnumEntityDefaultDefault.getGetterExpression().getExpression());
         assertEquals(mappedEnumEntityDefaultDefault, mappedEnumEntityDefault.getDefaultValue());
-        TransferAttribute mappedEnumEntityDefaultDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_mappedEnumEntityDefault_Default_Entity");
+        TransferAttribute mappedEnumEntityDefaultDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_enum_Default_Entity");
         assertEquals(mappedEnumEntityDefaultDefaultAttribute.getBinding(), mappedEnumEntityDefaultDefault);        
 
         TransferAttribute mappedEnumAncestorEntityDefault = assertMappedTransferObjectAttribute("Mapped", "mappedEnumAncestorEntityDefault");
@@ -187,7 +187,7 @@ public class JslTransferObjectConstructor2PsmTransferObjectTypeTest extends Abst
         DataProperty mappedEnumAncestorEntityDefaultDefault = assertDataProperty("_EntityAncestor", "_enumAncestor_Default_EntityAncestor");
         assertEquals("TransferObjectConstructorModel::TransferObjectConstructorModel::MyEnum#Atomic", mappedEnumAncestorEntityDefaultDefault.getGetterExpression().getExpression());
         assertEquals(mappedEnumAncestorEntityDefaultDefault, mappedEnumAncestorEntityDefault.getDefaultValue());
-        TransferAttribute mappedEnumAncestorEntityDefaultDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_mappedEnumAncestorEntityDefault_Default_EntityAncestor");
+        TransferAttribute mappedEnumAncestorEntityDefaultDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_enumAncestor_Default_EntityAncestor");
         assertEquals(mappedEnumAncestorEntityDefaultDefaultAttribute.getBinding(), mappedEnumAncestorEntityDefaultDefault);        
 
         TransferAttribute mappedAttributeAncestorEntityDefault = assertMappedTransferObjectAttribute("Mapped", "mappedAttributeAncestorEntityDefault");
@@ -197,7 +197,7 @@ public class JslTransferObjectConstructor2PsmTransferObjectTypeTest extends Abst
         DataProperty mappedAttributeAncestorEntityDefaultDefault = assertDataProperty("_EntityAncestor", "_attributeAncestor_Default_EntityAncestor");
         assertEquals("(-1)", mappedAttributeAncestorEntityDefaultDefault.getGetterExpression().getExpression());
         assertEquals(mappedAttributeAncestorEntityDefaultDefault, mappedAttributeAncestorEntityDefault.getDefaultValue());
-        TransferAttribute mappedAttributeAncestorEntityDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_mappedAttributeAncestorEntityDefault_Default_EntityAncestor");
+        TransferAttribute mappedAttributeAncestorEntityDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_attributeAncestor_Default_EntityAncestor");
         assertEquals(mappedAttributeAncestorEntityDefaultAttribute.getBinding(), mappedAttributeAncestorEntityDefaultDefault);
 
         TransferAttribute mappedIdentifierAncestorEntityDefault = assertMappedTransferObjectAttribute("Mapped", "mappedIdentifierAncestorEntityDefault");
@@ -207,7 +207,7 @@ public class JslTransferObjectConstructor2PsmTransferObjectTypeTest extends Abst
         DataProperty mappedIdentifierAncestorEntityDefaultDefault = assertDataProperty("_EntityAncestor", "_identifierAncestor_Default_EntityAncestor");
         assertEquals("(-1)", mappedIdentifierAncestorEntityDefaultDefault.getGetterExpression().getExpression());
         assertEquals(mappedIdentifierAncestorEntityDefaultDefault, mappedIdentifierAncestorEntityDefault.getDefaultValue());
-        TransferAttribute mappedIdentifierAncestorEntityDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_mappedIdentifierAncestorEntityDefault_Default_EntityAncestor");
+        TransferAttribute mappedIdentifierAncestorEntityDefaultAttribute = assertMappedTransferObjectAttribute("Mapped", "_identifierAncestor_Default_EntityAncestor");
         assertEquals(mappedIdentifierAncestorEntityDefaultAttribute.getBinding(), mappedIdentifierAncestorEntityDefaultDefault);
 
         

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <judo-dispatcher-api-version>1.0.3.20230826_230134_1ce94d88_develop</judo-dispatcher-api-version>
         <judo-operation-utils-version>1.1.3.20231117_040612_4e414fae_develop</judo-operation-utils-version>
 
-        <judo-runtime-core-version>1.0.6.20231206_161100_cb031c24_feature_JNG_JNG_5075_backend_not_populating_missing_required_fields</judo-runtime-core-version>
+        <judo-runtime-core-version>1.0.6.20231206_195425_dc90023e_feature_JNG_JNG_5075_backend_not_populating_missing_required_fields</judo-runtime-core-version>
         <structured-map-proxy-version>2.0.0.20231122_182717_c1fe065e_develop</structured-map-proxy-version>
         <judo-tatami-base-version>1.1.6.20231201_161205_6b45a0be_develop</judo-tatami-base-version>
         <judo-tatami-core-version>1.1.4.20231107_041032_332be90a_develop</judo-tatami-core-version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <judo-dispatcher-api-version>1.0.3.20230826_230134_1ce94d88_develop</judo-dispatcher-api-version>
         <judo-operation-utils-version>1.1.3.20231117_040612_4e414fae_develop</judo-operation-utils-version>
 
-        <judo-runtime-core-version>1.0.6.20231202_040604_4a05f821_develop</judo-runtime-core-version>
+        <judo-runtime-core-version>1.0.6.20231206_161100_cb031c24_feature_JNG_JNG_5075_backend_not_populating_missing_required_fields</judo-runtime-core-version>
         <structured-map-proxy-version>2.0.0.20231122_182717_c1fe065e_develop</structured-map-proxy-version>
         <judo-tatami-base-version>1.1.6.20231201_161205_6b45a0be_develop</judo-tatami-base-version>
         <judo-tatami-core-version>1.1.4.20231107_041032_332be90a_develop</judo-tatami-core-version>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5075" title="JNG-5075" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5075</a>  ESM backend not populating missing required fields with default values on CRUD create operations (implicitly)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

