### PR TITLE
JNG-5726 Updatable Deletable Key Is Removed By IdentifierSigner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <judo-dispatcher-api-version>1.0.3.20230826_230134_1ce94d88_develop</judo-dispatcher-api-version>
         <judo-operation-utils-version>1.1.3.20240414_042846_45b9c1dd_develop</judo-operation-utils-version>
 
-        <judo-runtime-core-version>1.0.6.20240419_083455_7d03cdd1_develop</judo-runtime-core-version>
+        <judo-runtime-core-version>1.0.6.20240517_134841_a358bfb3_feature_JNG_5726_UpdatableDeletableKeyIsRemovedByIdentifierSigner</judo-runtime-core-version>
         <judo-tatami-base-version>1.1.6.20240414_043749_1d165ed2_develop</judo-tatami-base-version>
         <judo-tatami-core-version>1.1.4.20240414_042056_ec303c5b_develop</judo-tatami-core-version>
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5726" title="JNG-5726" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5726</a>  The __updatable and __deletable flag is overrided in identifier signer
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
JNG-5726 Updatable Deletable Key Is Removed By IdentifierSigner